### PR TITLE
fix: rollback to previous Authorino API v1beta2 to support Authorino Tech Preview 1.1.1

### DIFF
--- a/internal/controller/config/templates/istio/authconfig.yaml.tmpl
+++ b/internal/controller/config/templates/istio/authconfig.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: authorino.kuadrant.io/v1beta3
+apiVersion: authorino.kuadrant.io/v1beta2
 kind: AuthConfig
 metadata:
   name: {{.Name}}
@@ -36,8 +36,8 @@ spec:
       kubernetesSubjectAccessReview:
         user:
           selector: auth.identity.user.username
-        authorizationGroups:
-          selector: auth.identity.user.groups
+        groups:
+          - {{.Name}}-users
         resourceAttributes:
           verb:
             value: get

--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -645,7 +645,7 @@ func (r *ModelRegistryReconciler) createOrUpdateAuthConfig(ctx context.Context, 
 
 func CreateAuthConfig() *unstructured.Unstructured {
 	authConfig := unstructured.Unstructured{}
-	authConfig.SetGroupVersionKind(schema.GroupVersionKind{Group: "authorino.kuadrant.io", Version: "v1beta3", Kind: "AuthConfig"})
+	authConfig.SetGroupVersionKind(schema.GroupVersionKind{Group: "authorino.kuadrant.io", Version: "v1beta2", Kind: "AuthConfig"})
 	return &authConfig
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Rollback to previous Authorino API v1beta2 to support Authorino Tech Preview 1.1.1 for rhoai-2.17

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually in a local cluster and verified that it works with Authorino tech-preview v1.1.1

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work