### PR TITLE
Revert "fix: rollback to previous Authorino API v1beta2 to support Au…

### DIFF
--- a/internal/controller/config/templates/istio/authconfig.yaml.tmpl
+++ b/internal/controller/config/templates/istio/authconfig.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: authorino.kuadrant.io/v1beta2
+apiVersion: authorino.kuadrant.io/v1beta3
 kind: AuthConfig
 metadata:
   name: {{.Name}}
@@ -36,8 +36,8 @@ spec:
       kubernetesSubjectAccessReview:
         user:
           selector: auth.identity.user.username
-        groups:
-          - {{.Name}}-users
+        authorizationGroups:
+          selector: auth.identity.user.groups
         resourceAttributes:
           verb:
             value: get

--- a/internal/controller/modelregistry_controller.go
+++ b/internal/controller/modelregistry_controller.go
@@ -646,7 +646,7 @@ func (r *ModelRegistryReconciler) createOrUpdateAuthConfig(ctx context.Context, 
 
 func CreateAuthConfig() *unstructured.Unstructured {
 	authConfig := unstructured.Unstructured{}
-	authConfig.SetGroupVersionKind(schema.GroupVersionKind{Group: "authorino.kuadrant.io", Version: "v1beta2", Kind: "AuthConfig"})
+	authConfig.SetGroupVersionKind(schema.GroupVersionKind{Group: "authorino.kuadrant.io", Version: "v1beta3", Kind: "AuthConfig"})
 	return &authConfig
 }
 


### PR DESCRIPTION
…thorino Tech Preview 1.1.1"

Switches Authorino supported version to stable channel with v1beta3 API version.

This reverts commit 95e7ba53057f69b9765c43d9b426b2330d68574f.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
