### PR TITLE
Fix: add istio field to support in RHOAI 2.2=+

### DIFF
--- a/config/samples/mysql/modelregistry_v1beta1_modelregistry.yaml
+++ b/config/samples/mysql/modelregistry_v1beta1_modelregistry.yaml
@@ -12,6 +12,19 @@ spec:
   # TODO(user): Add fields here
   grpc:
     port: 9090
+  istio:
+    gateway:
+      grpc:
+        gatewayRoute: enabled
+        port: 443
+        tls:
+          mode: SIMPLE
+      rest:
+        gatewayRoute: enabled
+        port: 443
+        tls:
+          mode: SIMPLE
+    tlsMode: ISTIO_MUTUAL
   rest:
     port: 8080
     serviceRoute: disabled


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When deploying this chart in `RHOAI 2.2` I was getting an error and the chart wasn't deployed, Adding the `istio` field fixed it.
