### PR TITLE
fix: change oauth-proxy image to multi-arch

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -78,7 +78,7 @@ spec:
           - name: REST_IMAGE
             value: quay.io/opendatahub/model-registry:latest
           - name: OAUTH_PROXY_IMAGE
-            value: quay.io/openshift/origin-oauth-proxy:latest
+            value: registry.redhat.io/openshift4/ose-oauth-proxy:latest
           - name: ENABLE_WEBHOOKS
             value: "false"
           - name: CREATE_AUTH_RESOURCES

--- a/internal/controller/config/defaults.go
+++ b/internal/controller/config/defaults.go
@@ -45,7 +45,7 @@ const (
 	OAuthProxyImage         = "OAUTH_PROXY_IMAGE"
 	DefaultGrpcImage        = "quay.io/opendatahub/mlmd-grpc-server:latest"
 	DefaultRestImage        = "quay.io/opendatahub/model-registry:latest"
-	DefaultOAuthProxyImage  = "quay.io/openshift/origin-oauth-proxy:latest"
+	DefaultOAuthProxyImage  = "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
 	RouteDisabled           = "disabled"
 	RouteEnabled            = "enabled"
 	DefaultIstioIngressName = "ingressgateway"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

fixes [RHOAIENG-31262](https://issues.redhat.com/browse/RHOAIENG-31262) for release 2.21

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
