### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-model-registry-operator-v2-22

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -30,7 +30,8 @@ USER 65532:65532
 ENTRYPOINT ["/manager"]
  
 LABEL com.redhat.component="odh-model-registry-operator-container" \
-      name="managed-open-data-hub/odh-model-registry-operator-rhel8" \
+      name="rhoai/odh-model-registry-operator-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.22::el9" \
       description="Manages lifecycle of RHOAI Model Registry custom resources and associated Kubernetes resources" \
       summary="odh-model-registry-operator-container" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
