### PR TITLE
bugfix: add manifests-template folder to konflux dockerfile

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -20,11 +20,13 @@ COPY . .
 # Build
 USER root
 RUN CGO_ENABLED=1 GOOS=linux GOEXPERIMENT=strictfipsruntime go build -buildvcs=false -tags strictfipsruntime -a -o manager .
+RUN bash hack/get_aihub_manifests.sh /workspace/opt/manifests-template
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
  
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/opt/manifests-template/ /opt/manifests-template/
  
 USER 65532:65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When running the operator in `aihub` mode, the process validates the existence of the manifests template directory at `/opt/manifests-template` (`cmd/aihub.go`). 

In downstream Konflux builds, `Dockerfile.konflux` was compiling the Go manager binary but omitting the manifest assembly script (`hack/get_aihub_manifests.sh`) and the `COPY` instruction into `/opt/manifests-template/`. This caused the deployed `aihub-controller-manager` pod to CrashLoopBackOff with:
```text
Error: manifests template path is not accessible "/opt/manifests-template": stat /opt/manifests-template: no such file or directory
```
This PR aligns Dockerfile.konflux with the upstream Dockerfile by:
1. Running bash hack/get_aihub_manifests.sh /workspace/opt/manifests-template in the builder stage.
2. Copying /workspace/opt/manifests-template/ to /opt/manifests-template/ in the runtime stage.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Verified that hack/get_aihub_manifests.sh generates the expected manifest tree in /workspace/opt/manifests-template.
- Confirmed step parity against upstream Dockerfile.
- Tested the container image startup with the aihub subcommand to ensure /opt/manifests-template is found and accessible.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
