### PR TITLE
Merge main into 3.6-ea.1

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -22,7 +22,7 @@ USER root
 RUN CGO_ENABLED=1 GOOS=linux GOEXPERIMENT=strictfipsruntime go build -buildvcs=false -tags strictfipsruntime -a -o manager .
 RUN bash hack/get_aihub_manifests.sh /workspace/opt/manifests-template
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:580752f96d36c4132bffd30f9c34865bf4bd87f6aa161c969d117f21732e50f7
  
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/internal/controller/catalog_controller.go
+++ b/internal/controller/catalog_controller.go
@@ -1365,12 +1365,6 @@ func (r *CatalogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	b = b.Watches(
-		&corev1.ConfigMap{},
-		handler.EnqueueRequestsFromMapFunc(r.getCatalogsForConfigMap),
-		builder.WithPredicates(catalogSourceLabels),
-	)
-
 	labelsPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
@@ -1383,6 +1377,13 @@ func (r *CatalogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
+
+	b = b.Watches(
+		&corev1.ConfigMap{},
+		handler.EnqueueRequestsFromMapFunc(r.getCatalogsForConfigMap),
+		builder.WithPredicates(predicate.Or(catalogSourceLabels, labelsPredicate)),
+	)
+
 	b = b.Watches(
 		&rbac.ClusterRoleBinding{},
 		handler.EnqueueRequestsFromMapFunc(r.GetCatalogForClusterRoleBinding),

--- a/internal/controller/catalog_controller.go
+++ b/internal/controller/catalog_controller.go
@@ -103,6 +103,7 @@ type CatalogParams struct {
 	GatewayName             string
 	GatewayNamespace        string
 	HTTPRouteNamespace      string
+	PostgresSecretHash      string
 }
 
 func (r *CatalogReconciler) createPostgresParams(catalog *catalogv1alpha1.Catalog) *CatalogParams {
@@ -242,17 +243,40 @@ func (r *CatalogReconciler) ensureCatalogResources(ctx context.Context, catalog 
 	}
 
 	catalogParams := r.buildCatalogParams(catalog, adminGroups, labeledSources)
+	postgresParams := r.createPostgresParams(catalog)
 
 	crOwner := metav1.NewControllerRef(catalog, catalogv1alpha1.GroupVersion.WithKind("Catalog"))
 
+	result := ResourceUnchanged
+
+	if !r.SkipCatalogDBCreation {
+		res, pgSecret, err := r.createOrUpdatePostgresSecret(ctx, postgresParams, crOwner)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if res != ResourceUnchanged {
+			result = res
+		}
+		if pgSecret != nil {
+			hash := computeSecretDataHash(pgSecret.Data)
+			catalogParams.PostgresSecretHash = hash
+			postgresParams.PostgresSecretHash = hash
+		}
+	} else {
+		log.Info("Skipping catalog DB creation as configured")
+	}
+
 	// Create or update ServiceAccount
-	result, err := r.createOrUpdateServiceAccount(ctx, catalogParams, "catalog-serviceaccount.yaml.tmpl", crOwner)
+	result2, err := r.createOrUpdateServiceAccount(ctx, catalogParams, "catalog-serviceaccount.yaml.tmpl", crOwner)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	if result2 != ResourceUnchanged {
+		result = result2
+	}
 
 	// Create or update the managed default sources ConfigMap
-	result2, err := r.createOrUpdateConfigmap(ctx, catalogParams, "catalog-default-configmap.yaml.tmpl", crOwner)
+	result2, err = r.createOrUpdateConfigmap(ctx, catalogParams, "catalog-default-configmap.yaml.tmpl", crOwner)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -349,8 +373,6 @@ func (r *CatalogReconciler) ensureCatalogResources(ctx context.Context, catalog 
 		result = result2
 	}
 
-	postgresParams := r.createPostgresParams(catalog)
-
 	// Delete legacy postgres PVC if present
 	var oldPVC corev1.PersistentVolumeClaim
 	err = r.Get(ctx, types.NamespacedName{Name: catalogPostgresComponent, Namespace: catalog.Namespace}, &oldPVC)
@@ -364,15 +386,7 @@ func (r *CatalogReconciler) ensureCatalogResources(ctx context.Context, catalog 
 
 	// Create PostgreSQL resources only if not skipping DB creation
 	if !r.SkipCatalogDBCreation {
-		result2, err := r.createOrUpdatePostgresSecret(ctx, postgresParams, crOwner)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		if result2 != ResourceUnchanged {
-			result = result2
-		}
-
-		result2, _, err = r.createOrUpdateDeployment(ctx, postgresParams, "catalog-postgres-deployment.yaml.tmpl", crOwner)
+		result2, _, err := r.createOrUpdateDeployment(ctx, postgresParams, "catalog-postgres-deployment.yaml.tmpl", crOwner)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -857,7 +871,7 @@ func (r *CatalogReconciler) createOrUpdateRoleBinding(ctx context.Context, param
 	return r.createOrUpdate(ctx, &rbac.RoleBinding{}, &rb)
 }
 
-func (r *CatalogReconciler) createOrUpdatePostgresSecret(ctx context.Context, params *CatalogParams, owner *metav1.OwnerReference) (OperationResult, error) {
+func (r *CatalogReconciler) createOrUpdatePostgresSecret(ctx context.Context, params *CatalogParams, owner *metav1.OwnerReference) (OperationResult, *corev1.Secret, error) {
 	log := klog.FromContext(ctx)
 	result := ResourceUnchanged
 
@@ -884,21 +898,32 @@ func (r *CatalogReconciler) createOrUpdatePostgresSecret(ctx context.Context, pa
 		}
 
 		for key, defaultValue := range requiredKeys {
-			if _, exists := existingSecret.Data[key]; !exists {
+			if len(existingSecret.Data[key]) == 0 {
 				log.Info("Adding missing key to existing secret", "secret", secretName, "key", key)
 				existingSecret.Data[key] = []byte(defaultValue)
 				needsUpdate = true
 			}
 		}
 
-		if _, exists := existingSecret.Data["database-password"]; !exists {
+		if len(existingSecret.Data["database-password"]) == 0 {
 			log.Info("Generating missing password for existing secret", "secret", secretName)
 			password, err := utils.RandBytes(16)
 			if err != nil {
 				log.Error(err, "Failed to generate random password for secret", "secret", secretName)
-				return result, fmt.Errorf("failed to generate random password: %w", err)
+				return result, nil, fmt.Errorf("failed to generate random password: %w", err)
 			}
 			existingSecret.Data["database-password"] = []byte(password)
+			needsUpdate = true
+		}
+
+		if len(existingSecret.Data["database-salt"]) == 0 {
+			log.Info("Generating missing salt for existing secret", "secret", secretName)
+			salt, err := utils.RandBytes(16)
+			if err != nil {
+				log.Error(err, "Failed to generate random salt for secret", "secret", secretName)
+				return result, nil, fmt.Errorf("failed to generate random salt: %w", err)
+			}
+			existingSecret.Data["database-salt"] = []byte(salt)
 			needsUpdate = true
 		}
 
@@ -927,17 +952,17 @@ func (r *CatalogReconciler) createOrUpdatePostgresSecret(ctx context.Context, pa
 		if needsUpdate {
 			if err := r.Update(ctx, existingSecret); err != nil {
 				log.Error(err, "Failed to update existing secret", "secret", secretName)
-				return result, err
+				return result, nil, err
 			}
 			log.Info("Successfully reconciled existing secret", "secret", secretName)
-			return ResourceUpdated, nil
+			return ResourceUpdated, existingSecret, nil
 		}
 
-		return ResourceUnchanged, nil
+		return ResourceUnchanged, existingSecret, nil
 	}
 
 	if !apierrors.IsNotFound(err) {
-		return result, err
+		return result, nil, err
 	}
 
 	log.Info("Creating postgres secret with random password", "secret", secretName)
@@ -945,7 +970,13 @@ func (r *CatalogReconciler) createOrUpdatePostgresSecret(ctx context.Context, pa
 	password, err := utils.RandBytes(16)
 	if err != nil {
 		log.Error(err, "Failed to generate random password for new secret", "secret", secretName)
-		return result, fmt.Errorf("failed to generate random password: %w", err)
+		return result, nil, fmt.Errorf("failed to generate random password: %w", err)
+	}
+
+	salt, err := utils.RandBytes(16)
+	if err != nil {
+		log.Error(err, "Failed to generate random salt for new secret", "secret", secretName)
+		return result, nil, fmt.Errorf("failed to generate random salt: %w", err)
 	}
 
 	newSecret := &corev1.Secret{
@@ -953,17 +984,22 @@ func (r *CatalogReconciler) createOrUpdatePostgresSecret(ctx context.Context, pa
 			Name:      secretName,
 			Namespace: params.Namespace,
 		},
-		StringData: map[string]string{
-			"database-name":     config.GetStringConfigWithDefault(config.CatalogPostgresDatabase, config.DefaultCatalogPostgresDatabase),
-			"database-user":     config.GetStringConfigWithDefault(config.CatalogPostgresUser, config.DefaultCatalogPostgresUser),
-			"database-password": password,
+		Data: map[string][]byte{
+			"database-name":     []byte(config.GetStringConfigWithDefault(config.CatalogPostgresDatabase, config.DefaultCatalogPostgresDatabase)),
+			"database-user":     []byte(config.GetStringConfigWithDefault(config.CatalogPostgresUser, config.DefaultCatalogPostgresUser)),
+			"database-password": []byte(password),
+			"database-salt":     []byte(salt),
 		},
 	}
 
 	r.applyLabels(&newSecret.ObjectMeta, params)
 	r.applyOwnerReference(&newSecret.ObjectMeta, owner)
 
-	return r.createOrUpdate(ctx, &corev1.Secret{}, newSecret)
+	res, err := r.createOrUpdate(ctx, &corev1.Secret{}, newSecret)
+	if err != nil {
+		return res, nil, err
+	}
+	return res, newSecret, nil
 }
 
 // fetchAuthConfig retrieves admin groups from the cluster-scoped Auth CR.
@@ -1172,6 +1208,7 @@ func (r *CatalogReconciler) Apply(params *CatalogParams, templateName string, ob
 		GatewayName             string
 		GatewayNamespace        string
 		HTTPRouteNamespace      string
+		PostgresSecretHash      string
 	}{
 		Name:                    params.Name,
 		Namespace:               params.Namespace,
@@ -1189,6 +1226,7 @@ func (r *CatalogReconciler) Apply(params *CatalogParams, templateName string, ob
 		GatewayName:             params.GatewayName,
 		GatewayNamespace:        params.GatewayNamespace,
 		HTTPRouteNamespace:      params.HTTPRouteNamespace,
+		PostgresSecretHash:      params.PostgresSecretHash,
 	}
 
 	return r.templateApplier.Apply(catalogParams, templateName, object)

--- a/internal/controller/catalog_controller_test.go
+++ b/internal/controller/catalog_controller_test.go
@@ -113,6 +113,8 @@ var _ = Describe("Catalog controller", func() {
 			Expect(dep.OwnerReferences).To(HaveLen(1))
 			Expect(dep.OwnerReferences[0].Kind).To(Equal("Catalog"))
 			Expect(dep.OwnerReferences[0].Name).To(Equal("catalog"))
+			catHash := dep.Spec.Template.Annotations["modelregistry.opendatahub.io/postgres-secret-hash"]
+			Expect(catHash).To(Not(BeEmpty()))
 
 			By("Checking created catalog Service")
 			svc := &corev1.Service{}
@@ -126,6 +128,7 @@ var _ = Describe("Catalog controller", func() {
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: "model-catalog-postgres", Namespace: namespaceName}, secret)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(secret.Data).To(HaveKey("database-password"))
+			Expect(secret.Data).To(HaveKey("database-salt"))
 			Expect(secret.OwnerReferences).To(HaveLen(1))
 			Expect(secret.OwnerReferences[0].Kind).To(Equal("Catalog"))
 
@@ -135,6 +138,8 @@ var _ = Describe("Catalog controller", func() {
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(pgDep.OwnerReferences).To(HaveLen(1))
 			Expect(pgDep.OwnerReferences[0].Kind).To(Equal("Catalog"))
+			pgHash := pgDep.Spec.Template.Annotations["modelregistry.opendatahub.io/postgres-secret-hash"]
+			Expect(pgHash).To(Equal(catHash))
 
 			By("Checking created postgres Service")
 			pgSvc := &corev1.Service{}
@@ -420,6 +425,164 @@ var _ = Describe("Catalog controller", func() {
 			By("Verifying the admin RoleBinding was deleted")
 			err = k8sClient.Get(ctx, rbName, &rb)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("Should update secret hash annotation on deployments when secret is updated", func() {
+			By("Creating a labeled source ConfigMap")
+			labeledCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "custom-source",
+					Namespace: namespaceName,
+					Labels: map[string]string{
+						catalogSourceLabel: "true",
+					},
+				},
+				Data: map[string]string{
+					sourcesFileName: "catalogs: []",
+				},
+			}
+			Expect(k8sClient.Create(ctx, labeledCM)).To(Succeed())
+
+			catalog := &catalogv1alpha1.Catalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "catalog",
+					Namespace: namespaceName,
+				},
+			}
+
+			By("Creating Catalog CR")
+			Expect(k8sClient.Create(ctx, catalog)).To(Succeed())
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "catalog",
+					Namespace: namespaceName,
+				},
+			}
+			_, err := catalogReconciler.Reconcile(ctx, req)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Getting initial deployments and checking secret hash annotation and labeled source volume")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "model-catalog", Namespace: namespaceName}, dep)).To(Succeed())
+			initialHash := dep.Spec.Template.Annotations["modelregistry.opendatahub.io/postgres-secret-hash"]
+			Expect(initialHash).To(Not(BeEmpty()))
+
+			var labeledVol *corev1.Volume
+			for i, v := range dep.Spec.Template.Spec.Volumes {
+				if v.Name == "labeled-custom-source" {
+					labeledVol = &dep.Spec.Template.Spec.Volumes[i]
+					break
+				}
+			}
+			Expect(labeledVol).To(Not(BeNil()))
+			Expect(labeledVol.ConfigMap).To(Not(BeNil()))
+
+			pgDep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "model-catalog-postgres", Namespace: namespaceName}, pgDep)).To(Succeed())
+			Expect(pgDep.Spec.Template.Annotations["modelregistry.opendatahub.io/postgres-secret-hash"]).To(Equal(initialHash))
+
+			By("Updating postgres Secret password")
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "model-catalog-postgres", Namespace: namespaceName}, secret)).To(Succeed())
+			secret.Data["database-password"] = []byte("updated-secret-password-12345")
+			Expect(k8sClient.Update(ctx, secret)).To(Succeed())
+
+			By("Reconciling after secret update")
+			_, err = catalogReconciler.Reconcile(ctx, req)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Checking updated deployments receive new secret hash annotation")
+			updatedDep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "model-catalog", Namespace: namespaceName}, updatedDep)).To(Succeed())
+			newHash := updatedDep.Spec.Template.Annotations["modelregistry.opendatahub.io/postgres-secret-hash"]
+			Expect(newHash).To(Not(BeEmpty()))
+			Expect(newHash).To(Not(Equal(initialHash)))
+
+			updatedPgDep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "model-catalog-postgres", Namespace: namespaceName}, updatedPgDep)).To(Succeed())
+			Expect(updatedPgDep.Spec.Template.Annotations["modelregistry.opendatahub.io/postgres-secret-hash"]).To(Equal(newHash))
+		})
+
+		It("Should add missing database-salt to existing secret during reconciliation", func() {
+			By("Pre-creating a postgres secret missing database-salt")
+			existingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "model-catalog-postgres",
+					Namespace: namespaceName,
+				},
+				Data: map[string][]byte{
+					"database-name":     []byte("catalog"),
+					"database-user":     []byte("catalog"),
+					"database-password": []byte("existingpassword"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, existingSecret)).To(Succeed())
+
+			catalog := &catalogv1alpha1.Catalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "catalog",
+					Namespace: namespaceName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, catalog)).To(Succeed())
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "catalog",
+					Namespace: namespaceName,
+				},
+			}
+			_, err := catalogReconciler.Reconcile(ctx, req)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Verifying secret now contains database-salt")
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "model-catalog-postgres", Namespace: namespaceName}, secret)).To(Succeed())
+			Expect(secret.Data).To(HaveKey("database-salt"))
+			Expect(secret.Data["database-salt"]).To(Not(BeEmpty()))
+			Expect(string(secret.Data["database-password"])).To(Equal("existingpassword"))
+		})
+
+		It("Should populate database-salt when existing secret has empty database-salt during reconciliation", func() {
+			By("Pre-creating a postgres secret with empty database-salt")
+			existingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "model-catalog-postgres",
+					Namespace: namespaceName,
+				},
+				Data: map[string][]byte{
+					"database-name":     []byte("catalog"),
+					"database-user":     []byte("catalog"),
+					"database-password": []byte("existingpassword"),
+					"database-salt":     []byte(""),
+				},
+			}
+			Expect(k8sClient.Create(ctx, existingSecret)).To(Succeed())
+
+			catalog := &catalogv1alpha1.Catalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "catalog",
+					Namespace: namespaceName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, catalog)).To(Succeed())
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "catalog",
+					Namespace: namespaceName,
+				},
+			}
+			_, err := catalogReconciler.Reconcile(ctx, req)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Verifying secret now contains populated database-salt")
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "model-catalog-postgres", Namespace: namespaceName}, secret)).To(Succeed())
+			Expect(secret.Data).To(HaveKey("database-salt"))
+			Expect(secret.Data["database-salt"]).To(Not(BeEmpty()))
+			Expect(string(secret.Data["database-password"])).To(Equal("existingpassword"))
 		})
 	})
 })

--- a/internal/controller/catalog_controller_test.go
+++ b/internal/controller/catalog_controller_test.go
@@ -162,6 +162,14 @@ var _ = Describe("Catalog controller", func() {
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: "model-catalog-kube-rbac-proxy-config", Namespace: namespaceName}, cm)
 			Expect(err).To(Not(HaveOccurred()))
 
+			By("Checking created user-sources ConfigMaps and verifying no owner references")
+			for _, cmName := range []string{"model-catalog-sources", "mcp-catalog-sources", "agent-catalog-sources"} {
+				userCM := &corev1.ConfigMap{}
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: cmName, Namespace: namespaceName}, userCM)
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(userCM.OwnerReferences).To(BeEmpty())
+			}
+
 			crb := &rbac.ClusterRoleBinding{}
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: "model-catalog-auth-delegator"}, crb)
 			Expect(err).To(Not(HaveOccurred()))
@@ -583,6 +591,95 @@ var _ = Describe("Catalog controller", func() {
 			Expect(secret.Data).To(HaveKey("database-salt"))
 			Expect(secret.Data["database-salt"]).To(Not(BeEmpty()))
 			Expect(string(secret.Data["database-password"])).To(Equal("existingpassword"))
+		})
+
+		It("Should recreate user-sources ConfigMaps with empty owner references if deleted", func() {
+			catalog := &catalogv1alpha1.Catalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "catalog",
+					Namespace: namespaceName,
+				},
+			}
+
+			By("Creating Catalog CR")
+			err := k8sClient.Create(ctx, catalog)
+			Expect(err).To(Not(HaveOccurred()))
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "catalog",
+					Namespace: namespaceName,
+				},
+			}
+			_, err = catalogReconciler.Reconcile(ctx, req)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Deleting one of the user-sources ConfigMaps")
+			cmToDelete := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "model-catalog-sources",
+					Namespace: namespaceName,
+				},
+			}
+			err = k8sClient.Delete(ctx, cmToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Reconciling again")
+			_, err = catalogReconciler.Reconcile(ctx, req)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Verifying the ConfigMap was recreated with empty OwnerReferences")
+			recreatedCM := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "model-catalog-sources", Namespace: namespaceName}, recreatedCM)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(recreatedCM.OwnerReferences).To(BeEmpty())
+		})
+
+		It("Should retain pre-existing user-sources ConfigMaps data without adding owner references", func() {
+			By("Pre-creating user-sources ConfigMaps without owner references and with custom data")
+			customData := map[string]string{
+				"sources.yaml": "catalogs:\n  - name: custom-source\n    type: yaml\n",
+			}
+
+			for _, cmName := range []string{"model-catalog-sources", "mcp-catalog-sources", "agent-catalog-sources"} {
+				preExistingCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cmName,
+						Namespace: namespaceName,
+					},
+					Data: customData,
+				}
+				err := k8sClient.Create(ctx, preExistingCM)
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
+			By("Creating Catalog CR and reconciling")
+			catalog := &catalogv1alpha1.Catalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "catalog",
+					Namespace: namespaceName,
+				},
+			}
+			err := k8sClient.Create(ctx, catalog)
+			Expect(err).To(Not(HaveOccurred()))
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "catalog",
+					Namespace: namespaceName,
+				},
+			}
+			_, err = catalogReconciler.Reconcile(ctx, req)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Verifying that pre-existing user-sources ConfigMaps retain custom data and do not get owner references added")
+			for _, cmName := range []string{"model-catalog-sources", "mcp-catalog-sources", "agent-catalog-sources"} {
+				adoptedCM := &corev1.ConfigMap{}
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: cmName, Namespace: namespaceName}, adoptedCM)
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(adoptedCM.OwnerReferences).To(BeEmpty())
+				Expect(adoptedCM.Data).To(Equal(customData))
+			}
 		})
 	})
 })

--- a/internal/controller/config/templates/catalog/catalog-deployment.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-deployment.yaml.tmpl
@@ -27,6 +27,9 @@ spec:
         app.kubernetes.io/name: {{.Name}}
       annotations:
         openshift.io/required-scc: restricted-v2
+        {{- if .PostgresSecretHash}}
+        modelregistry.opendatahub.io/postgres-secret-hash: "{{.PostgresSecretHash}}"
+        {{- end}}
     spec:
       securityContext:
         seccompProfile:

--- a/internal/controller/config/templates/catalog/catalog-postgres-deployment.yaml.tmpl
+++ b/internal/controller/config/templates/catalog/catalog-postgres-deployment.yaml.tmpl
@@ -30,6 +30,10 @@ spec:
         component: {{.Name}}
         app.kubernetes.io/name: {{.Name}}-postgres
         sidecar.istio.io/inject: "false"
+      {{- if .PostgresSecretHash}}
+      annotations:
+        modelregistry.opendatahub.io/postgres-secret-hash: "{{.PostgresSecretHash}}"
+      {{- end}}
     spec:
       containers:
       - env:

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -14,7 +14,11 @@ package controller
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -218,4 +222,37 @@ func (r *ResourceManager) CreateIfNotExists(ctx context.Context, currObj client.
 		return result, err
 	}
 	return result, nil
+}
+
+// computeSecretDataHash returns a deterministic hex-encoded HMAC-SHA-256 hash of a secret's data map
+// using a domain-separated key or per-secret salt to mitigate CWE-200 offline dictionary attacks.
+// If data is empty or nil (or contains only database-salt), it returns an empty string.
+func computeSecretDataHash(data map[string][]byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+
+	salt := data["database-salt"]
+	if len(salt) == 0 {
+		salt = []byte("modelregistry.opendatahub.io/postgres-secret-hash")
+	}
+
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		if k == "database-salt" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	if len(keys) == 0 {
+		return ""
+	}
+	sort.Strings(keys)
+
+	mac := hmac.New(sha256.New, salt)
+	for _, k := range keys {
+		mac.Write([]byte(k))
+		mac.Write(data[k])
+	}
+	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/internal/controller/util_test.go
+++ b/internal/controller/util_test.go
@@ -1,0 +1,89 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("util functions", func() {
+	Context("computeSecretDataHash", func() {
+		It("should return empty string for nil or empty map", func() {
+			Expect(computeSecretDataHash(nil)).To(Equal(""))
+			Expect(computeSecretDataHash(map[string][]byte{})).To(Equal(""))
+		})
+
+		It("should return deterministic hash regardless of key iteration order", func() {
+			data1 := map[string][]byte{
+				"database-name":     []byte("mydb"),
+				"database-user":     []byte("myuser"),
+				"database-password": []byte("mypassword"),
+			}
+			data2 := map[string][]byte{
+				"database-password": []byte("mypassword"),
+				"database-name":     []byte("mydb"),
+				"database-user":     []byte("myuser"),
+			}
+
+			hash1 := computeSecretDataHash(data1)
+			hash2 := computeSecretDataHash(data2)
+
+			Expect(hash1).To(Not(BeEmpty()))
+			Expect(hash1).To(Equal(hash2))
+		})
+
+		It("should return different hash when data changes", func() {
+			data1 := map[string][]byte{
+				"database-password": []byte("password123"),
+			}
+			data2 := map[string][]byte{
+				"database-password": []byte("password456"),
+			}
+
+			hash1 := computeSecretDataHash(data1)
+			hash2 := computeSecretDataHash(data2)
+
+			Expect(hash1).To(Not(BeEmpty()))
+			Expect(hash2).To(Not(BeEmpty()))
+			Expect(hash1).To(Not(Equal(hash2)))
+		})
+
+		It("should alter the HMAC hash for identical payload data when database-salt is specified or changed", func() {
+			payload1 := map[string][]byte{
+				"database-name":     []byte("mydb"),
+				"database-user":     []byte("myuser"),
+				"database-password": []byte("mypassword"),
+			}
+			payload2 := map[string][]byte{
+				"database-name":     []byte("mydb"),
+				"database-user":     []byte("myuser"),
+				"database-password": []byte("mypassword"),
+				"database-salt":     []byte("salt-value-1"),
+			}
+			payload3 := map[string][]byte{
+				"database-name":     []byte("mydb"),
+				"database-user":     []byte("myuser"),
+				"database-password": []byte("mypassword"),
+				"database-salt":     []byte("salt-value-2"),
+			}
+
+			hash1 := computeSecretDataHash(payload1)
+			hash2 := computeSecretDataHash(payload2)
+			hash3 := computeSecretDataHash(payload3)
+
+			Expect(hash1).To(Not(BeEmpty()))
+			Expect(hash2).To(Not(BeEmpty()))
+			Expect(hash3).To(Not(BeEmpty()))
+
+			Expect(hash1).To(Not(Equal(hash2)))
+			Expect(hash2).To(Not(Equal(hash3)))
+			Expect(hash1).To(Not(Equal(hash3)))
+		})
+
+		It("should return empty string when data contains only database-salt", func() {
+			data := map[string][]byte{
+				"database-salt": []byte("salt-value"),
+			}
+			Expect(computeSecretDataHash(data)).To(Equal(""))
+		})
+	})
+})


### PR DESCRIPTION
## Description
Periodic merge of `main` into `rhoai-3.6-ea.1`. Brings the following commits into the release branch:

- fix(catalog): recreate user's cms on deletion (#650)
- fix(catalog): add secret hash annotation to refresh postgres and catalog pods on secret changes (#649)
- chore(deps): update registry.access.redhat.com/ubi9/ubi-minimal docker digest to 580752f (#1056)

## How Has This Been Tested?
Branch-to-branch merge; merges cleanly with no conflicts. Changes were already tested in their originating PRs.

## Merge criteria:
- [ ] The commits have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work